### PR TITLE
Fix/#48 유저 탈퇴 로직 수정

### DIFF
--- a/backend/src/main/java/com/example/coffee/user/controller/UserController.java
+++ b/backend/src/main/java/com/example/coffee/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.coffee.user.controller;
 
+import com.example.coffee.security.SecurityUtil;
 import com.example.coffee.user.controller.dto.CreateUserRequest;
 import com.example.coffee.user.controller.dto.CreateUserResponse;
 import com.example.coffee.user.controller.dto.LoginRequest;
@@ -58,7 +59,7 @@ public class UserController {
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/me")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteUser(@RequestHeader("Authorization") String token) {
-        userService.deleteUserByToken(token);
+    public void deleteUser() {
+        userService.deleteCurrentUser(SecurityUtil.getCurrentUserWithLogin());
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

현재 로그인된 유저 탈퇴

## ➕ 추가/변경된 기능

- 현재 로그인 정보로 탈퇴 처리
- 계정 정보는 남기고 권한만 변경하는 방식으로 탈퇴 구현

## 🗎 관련 이슈

#48 
